### PR TITLE
Add a Dockerfile to generate an image with external service builders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG GO_VER=1.14.4
+ARG ALPINE_VER=3.12
+
+FROM golang:${GO_VER}-alpine${ALPINE_VER}
+
+WORKDIR /go/src/github.com/hyperledgendary/fabric-ccs-builder
+
+COPY . .
+
+RUN go install -v ./cmd/...

--- a/README.md
+++ b/README.md
@@ -34,9 +34,3 @@ docker build \
   .
 ```
 
-TODO: where shall this image be pushed?  Can / should this image be published to docker hub?  For now publish this to the local docker registry running [adjacent to the KIND](https://github.com/jkneubuh/fabric-samples/tree/feature/kind-test-network/test-network-kind#kind) k8s.
-
-```shell 
-docker tag hyperledgendary/fabric-ccs-builder localhost:5000/hyperledgendary/fabric-ccs-builder
-docker push localhost:5000/hyperledgendary/fabric-ccs-builder
-```

--- a/README.md
+++ b/README.md
@@ -22,3 +22,21 @@ The documentation (above) contains references and examples of how you can use ba
 Golang code is more readily and reliably run the peer, and this repo contains the go binaries to do exactly this. 
 
 
+## Docker image 
+
+Build a docker image embedding the `build`, `release`, and `detect` binaries into the /go/bin directory.  For kube-native environments, the 
+fabric-ccs-builder image may be deployed as a sidecar in the peers.  When registered as an external builder in the peer / network configuration, 
+this allows us to deploy external chaincode as a service while using the base fabric images.
+
+```shell 
+docker build \
+  -t hyperledgendary/fabric-ccs-builder \
+  .
+```
+
+TODO: where shall this image be pushed?  Can / should this image be published to docker hub?  For now publish this to the local docker registry running [adjacent to the KIND](https://github.com/jkneubuh/fabric-samples/tree/feature/kind-test-network/test-network-kind#kind) k8s.
+
+```shell 
+docker tag hyperledgendary/fabric-ccs-builder localhost:5000/hyperledgendary/fabric-ccs-builder
+docker push localhost:5000/hyperledgendary/fabric-ccs-builder
+```


### PR DESCRIPTION
Hi @mbwhite, 

Thanks for assembling these utilities.  I added a simple Dockerfile to embed the fabric-ccs-builder binaries in an image - using this we will be able to mount the external builders as a sidecar to the peer deployments, skirting the challenges of alpine-sh and public fabric images.

That said, I'm not sure _where_ the image should be pushed?   The README has minimal instructions to publish the image up to a docker registry running on a local host, adjacent to the KIND cluster.  This is fine for a PoC but will not hold water for long.

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>